### PR TITLE
Lock down RLS on admin-owned tables

### DIFF
--- a/nextjs/src/app/api/cv-references/route.ts
+++ b/nextjs/src/app/api/cv-references/route.ts
@@ -6,13 +6,7 @@ import { logAuditEvent } from '@/lib/audit-logger';
 
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
 
-// Public client for reading active references
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
-// Admin client for write operations
+// Admin client for all DB access (RLS is locked down; service role bypasses it)
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
@@ -48,7 +42,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Public view: only active references with limited fields
-  const { data, error } = await supabase
+  const { data, error } = await supabaseAdmin
     .from('cv_references')
     .select('name, title, company, email, phone')
     .eq('is_active', true)

--- a/nextjs/src/app/api/public-contact/route.ts
+++ b/nextjs/src/app/api/public-contact/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
 export async function GET() {

--- a/nextjs/src/app/api/site-settings/route.ts
+++ b/nextjs/src/app/api/site-settings/route.ts
@@ -22,21 +22,20 @@ function sanitizeText(text: string): string {
   return text.replace(/<[^>]*>/g, '').trim();
 }
 
-// Public client for reading settings
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
-// Admin client for write operations
+// Admin client for all DB access (RLS is locked down; service role bypasses it)
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
 export async function GET() {
-  // Fetch the single settings row
-  const { data, error } = await supabase
+  // Gate private contact fields behind authentication. Anonymous callers only
+  // get the public_* fields; logged-in users get the full row. This matches
+  // the CV privacy model (canShowPrivateInfo = !!user).
+  const authClient = await createServerClient();
+  const { data: { user } } = await authClient.auth.getUser();
+
+  const { data, error } = await supabaseAdmin
     .from('site_settings')
     .select('contact_email, contact_phone, contact_address, public_email, public_address')
     .eq('id', 1)
@@ -51,6 +50,18 @@ export async function GET() {
         contact_address: '',
         public_email: null,
         public_address: null,
+      },
+    });
+  }
+
+  if (!user) {
+    return NextResponse.json({
+      settings: {
+        contact_email: '',
+        contact_phone: '',
+        contact_address: '',
+        public_email: data.public_email,
+        public_address: data.public_address,
       },
     });
   }

--- a/nextjs/supabase/migrations/20260414_rls_lockdown.sql
+++ b/nextjs/supabase/migrations/20260414_rls_lockdown.sql
@@ -1,0 +1,50 @@
+-- RLS lockdown: remove over-permissive policies on admin-owned tables.
+--
+-- Previous policies used auth.role() = 'authenticated' as a proxy for "admin",
+-- which is only safe if no one else can ever authenticate. With Supabase email
+-- signup enabled (default), any signed-in user could write whitelisted_emails,
+-- site_settings, cv_references and cv_styles. audit_logs had USING (true)
+-- which made it world-readable via the anon key.
+--
+-- Approach: drop every policy that granted write or admin-read access through
+-- the anon/authenticated roles. All admin operations go through API routes
+-- that use the SUPABASE_SERVICE_ROLE_KEY, and service_role bypasses RLS, so
+-- no replacement policies are needed for admin writes.
+--
+-- SELECT policies that legitimate public API routes (now switched to service
+-- role) used to rely on are also dropped.
+
+-- audit_logs: "Admin can view audit logs" was USING (true) → world-readable.
+-- INSERT policy was WITH CHECK (true) → any anon client could forge entries.
+DROP POLICY IF EXISTS "Admin can view audit logs" ON audit_logs;
+DROP POLICY IF EXISTS "Service role can insert audit logs" ON audit_logs;
+
+-- whitelisted_emails: authenticated users could add themselves (priv esc into
+-- the whitelist) and enumerate existing whitelist members.
+DROP POLICY IF EXISTS "Authenticated users can view whitelisted emails" ON whitelisted_emails;
+DROP POLICY IF EXISTS "Authenticated users can insert whitelisted emails" ON whitelisted_emails;
+DROP POLICY IF EXISTS "Authenticated users can delete whitelisted emails" ON whitelisted_emails;
+
+-- cv_references: authenticated users could tamper with real people's contact
+-- details. Public SELECT is also dropped — /api/cv-references now reads via
+-- the service role.
+DROP POLICY IF EXISTS "Anyone can view active references" ON cv_references;
+DROP POLICY IF EXISTS "Authenticated users can insert references" ON cv_references;
+DROP POLICY IF EXISTS "Authenticated users can update references" ON cv_references;
+DROP POLICY IF EXISTS "Authenticated users can delete references" ON cv_references;
+
+-- site_settings: authenticated users could overwrite contact info. Public
+-- SELECT is also dropped — /api/public-contact and /api/site-settings now
+-- read via the service role and gate private fields behind auth in the route.
+DROP POLICY IF EXISTS "Anyone can view settings" ON site_settings;
+DROP POLICY IF EXISTS "Authenticated users can update settings" ON site_settings;
+
+-- cv_styles: authenticated INSERT was unused by the app.
+DROP POLICY IF EXISTS "Authenticated users can insert cv_styles" ON cv_styles;
+
+-- rate_limits: "Service role has full access" was FOR ALL USING (true) WITH
+-- CHECK (true), which actually gave anon clients read/write to rate-limit
+-- state. Dropping the policy leaves RLS enabled with no policies, i.e. deny
+-- all for non-service-role; rate-limiter.ts uses the service role and keeps
+-- working.
+DROP POLICY IF EXISTS "Service role has full access" ON rate_limits;


### PR DESCRIPTION
Drop RLS policies that granted writes to any authenticated user (whitelisted_emails, cv_references, site_settings, cv_styles) and fix audit_logs/rate_limits policies that were effectively world-accessible. Switch public-contact, cv-references, and site-settings reads to the service role so the public SELECT policies can be dropped, and gate private contact fields in /api/site-settings GET behind auth.